### PR TITLE
Missing Korean verbs

### DIFF
--- a/blog_posts/korean-learning-notes.md
+++ b/blog_posts/korean-learning-notes.md
@@ -1034,7 +1034,7 @@ fa-icon: language
                   <!-- Generated from blog_posts/verbs_tenses.tsv (simple -다 verbs only; edit TSV, then run: python tools_update_verb_table.py) -->
                   <tr>
                     <td class="ko-cell"><div class="ko">가깝다</div><div class="rom">gakkapda</div></td>
-                    <td>to be close/near</td>
+                    <td>@level2/2025-12-12-Class-10.txt (Vocab; also Class 8 dialogue)</td>
                     <td class="ko-cell"><div class="ko">가까워요</div><div class="rom">gakkawoyo</div></td>
                     <td class="ko-cell"><div class="ko">가까웠어요</div><div class="rom">gakkawosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">가까울 거예요</div><div class="rom">gakkaul geoyeyo</div></td>
@@ -1080,6 +1080,13 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">건너요</div><div class="rom">geonneoyo</div></td>
                     <td class="ko-cell"><div class="ko">건넜어요</div><div class="rom">geonneosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">건널 거예요</div><div class="rom">geonneol geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">걷다</div><div class="rom">geotda</div></td>
+                    <td>to walk</td>
+                    <td class="ko-cell"><div class="ko">걸어요</div><div class="rom">georeoyo</div></td>
+                    <td class="ko-cell"><div class="ko">걸었어요</div><div class="rom">georeosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">걸을 거예요</div><div class="rom">georeul geoyeyo</div></td>
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">걸어가다</div><div class="rom">georeogada</div></td>
@@ -1146,7 +1153,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">길다</div><div class="rom">gilda</div></td>
-                    <td>to be long</td>
+                    <td>긴</td>
                     <td class="ko-cell"><div class="ko">길어요</div><div class="rom">gireoyo</div></td>
                     <td class="ko-cell"><div class="ko">길었어요</div><div class="rom">gireosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">길 거예요</div><div class="rom">gil geoyeyo</div></td>
@@ -1208,11 +1215,25 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">놀 거예요</div><div class="rom">nol geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">노래하다</div><div class="rom">noraehada</div></td>
+                    <td>to sing</td>
+                    <td class="ko-cell"><div class="ko">노래해요</div><div class="rom">noraehaeyo</div></td>
+                    <td class="ko-cell"><div class="ko">노래했어요</div><div class="rom">noraehaesseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">노래할 거예요</div><div class="rom">noraehal geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">늦다</div><div class="rom">neutda</div></td>
                     <td>to be late</td>
                     <td class="ko-cell"><div class="ko">늦어요</div><div class="rom">neujeoyo</div></td>
                     <td class="ko-cell"><div class="ko">늦었어요</div><div class="rom">neujeosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">늦을 거예요</div><div class="rom">neujeul geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">닫다</div><div class="rom">datda</div></td>
+                    <td>to close</td>
+                    <td class="ko-cell"><div class="ko">닫아요</div><div class="rom">dadayo</div></td>
+                    <td class="ko-cell"><div class="ko">닫았어요</div><div class="rom">dadasseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">닫을 거예요</div><div class="rom">dadeul geoyeyo</div></td>
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">달다</div><div class="rom">dalda</div></td>
@@ -1227,6 +1248,13 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">더워요</div><div class="rom">deowoyo</div></td>
                     <td class="ko-cell"><div class="ko">더웠어요</div><div class="rom">deowosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">더울 거예요</div><div class="rom">deoul geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">도와주다</div><div class="rom">dowajuda</div></td>
+                    <td>to help (someone)</td>
+                    <td class="ko-cell"><div class="ko">도와줘요</div><div class="rom">dowajwoyo</div></td>
+                    <td class="ko-cell"><div class="ko">도와줬어요</div><div class="rom">dowajwosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">도와줄 거예요</div><div class="rom">dowajul geoyeyo</div></td>
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">듣다</div><div class="rom">deutda</div></td>
@@ -1271,6 +1299,13 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">마를 거예요</div><div class="rom">mareul geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">마시다</div><div class="rom">masida</div></td>
+                    <td>to drink</td>
+                    <td class="ko-cell"><div class="ko">마셔요</div><div class="rom">masyeoyo</div></td>
+                    <td class="ko-cell"><div class="ko">마셨어요</div><div class="rom">masyeosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">마실 거예요</div><div class="rom">masil geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">만나다</div><div class="rom">mannada</div></td>
                     <td>to meet</td>
                     <td class="ko-cell"><div class="ko">만나요</div><div class="rom">mannayo</div></td>
@@ -1286,7 +1321,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">많다</div><div class="rom">manda</div></td>
-                    <td>to be many/much (only ㄴ pronounced)</td>
+                    <td>only ㄴ pronounced</td>
                     <td class="ko-cell"><div class="ko">많아요</div><div class="rom">manayo</div></td>
                     <td class="ko-cell"><div class="ko">많았어요</div><div class="rom">manasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">많을 거예요</div><div class="rom">maneul geoyeyo</div></td>
@@ -1376,6 +1411,20 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">배울 거예요</div><div class="rom">baeul geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">버리다</div><div class="rom">beorida</div></td>
+                    <td>to throw away</td>
+                    <td class="ko-cell"><div class="ko">버려요</div><div class="rom">beoryeoyo</div></td>
+                    <td class="ko-cell"><div class="ko">버렸어요</div><div class="rom">beoryeosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">버릴 거예요</div><div class="rom">beoril geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">벗다</div><div class="rom">beotda</div></td>
+                    <td>to take off (clothes)</td>
+                    <td class="ko-cell"><div class="ko">벗어요</div><div class="rom">beoseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">벗었어요</div><div class="rom">beoseosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">벗을 거예요</div><div class="rom">beoseul geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">보내다</div><div class="rom">bonaeda</div></td>
                     <td>to spend (time)</td>
                     <td class="ko-cell"><div class="ko">보내요</div><div class="rom">bonaeyo</div></td>
@@ -1425,6 +1474,13 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">사랑할 거예요</div><div class="rom">saranghal geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">산책하다</div><div class="rom">sanchaekhada</div></td>
+                    <td>to take a walk</td>
+                    <td class="ko-cell"><div class="ko">산책해요</div><div class="rom">sanchaekhaeyo</div></td>
+                    <td class="ko-cell"><div class="ko">산책했어요</div><div class="rom">sanchaekhaesseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">산책할 거예요</div><div class="rom">sanchaekhal geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">살다</div><div class="rom">salda</div></td>
                     <td>to live</td>
                     <td class="ko-cell"><div class="ko">살아요</div><div class="rom">sarayo</div></td>
@@ -1437,6 +1493,13 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">새요</div><div class="rom">saeyo</div></td>
                     <td class="ko-cell"><div class="ko">샜어요</div><div class="rom">saesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">샐 거예요</div><div class="rom">sael geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">서다</div><div class="rom">seoda</div></td>
+                    <td>to stand</td>
+                    <td class="ko-cell"><div class="ko">서요</div><div class="rom">seoyo</div></td>
+                    <td class="ko-cell"><div class="ko">섰어요</div><div class="rom">seosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">설 거예요</div><div class="rom">seol geoyeyo</div></td>
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">소개하다</div><div class="rom">sogaehada</div></td>
@@ -1453,10 +1516,17 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">쇼핑할 거예요</div><div class="rom">syopinghal geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">수영하다</div><div class="rom">suyeonghada</div></td>
+                    <td>to swim</td>
+                    <td class="ko-cell"><div class="ko">수영해요</div><div class="rom">suyeonghaeyo</div></td>
+                    <td class="ko-cell"><div class="ko">수영했어요</div><div class="rom">suyeonghaesseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">수영할 거예요</div><div class="rom">suyeonghal geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">쉬다</div><div class="rom">swida</div></td>
                     <td>to rest</td>
-                    <td class="ko-cell"><div class="ko">쉬어요</div><div class="rom">swieoyo</div></td>
-                    <td class="ko-cell"><div class="ko">쉬었어요</div><div class="rom">swieosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">쉬요</div><div class="rom">swiyo</div></td>
+                    <td class="ko-cell"><div class="ko">슀어요</div><div class="rom">swisseoyo</div></td>
                     <td class="ko-cell"><div class="ko">쉴 거예요</div><div class="rom">swil geoyeyo</div></td>
                   </tr>
                   <tr>
@@ -1530,6 +1600,20 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">연락할 거예요</div><div class="rom">yeonrakhal geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">열다</div><div class="rom">yeolda</div></td>
+                    <td>to open</td>
+                    <td class="ko-cell"><div class="ko">열어요</div><div class="rom">yeoreoyo</div></td>
+                    <td class="ko-cell"><div class="ko">열었어요</div><div class="rom">yeoreosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">열 거예요</div><div class="rom">yeol geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">여행하다</div><div class="rom">yeohaenghada</div></td>
+                    <td>to travel</td>
+                    <td class="ko-cell"><div class="ko">여행해요</div><div class="rom">yeohaenghaeyo</div></td>
+                    <td class="ko-cell"><div class="ko">여행했어요</div><div class="rom">yeohaenghaesseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">여행할 거예요</div><div class="rom">yeohaenghal geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">예쁘다</div><div class="rom">yeppeuda</div></td>
                     <td>to be pretty</td>
                     <td class="ko-cell"><div class="ko">예뻐요</div><div class="rom">yeppeoyo</div></td>
@@ -1580,7 +1664,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">읊다</div><div class="rom">eulda</div></td>
-                    <td>to recite/chant (only ㅍ pronounced)</td>
+                    <td>only ㅍ is pronounced (exception to first consonant rule)</td>
                     <td class="ko-cell"><div class="ko">읊어요</div><div class="rom">eupeoyo</div></td>
                     <td class="ko-cell"><div class="ko">읊었어요</div><div class="rom">eupeosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">읊을 거예요</div><div class="rom">eupeul geoyeyo</div></td>
@@ -1600,6 +1684,13 @@ fa-icon: language
                     <td class="ko-cell"><div class="ko">이야기할 거예요</div><div class="rom">iyagihal geoyeyo</div></td>
                   </tr>
                   <tr>
+                    <td class="ko-cell"><div class="ko">일어나다</div><div class="rom">ireonada</div></td>
+                    <td>to wake up</td>
+                    <td class="ko-cell"><div class="ko">일어나요</div><div class="rom">ireonayo</div></td>
+                    <td class="ko-cell"><div class="ko">일어났어요</div><div class="rom">ireonasseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">일어날 거예요</div><div class="rom">ireonal geoyeyo</div></td>
+                  </tr>
+                  <tr>
                     <td class="ko-cell"><div class="ko">일하다</div><div class="rom">ilhada</div></td>
                     <td>to work</td>
                     <td class="ko-cell"><div class="ko">일해요</div><div class="rom">ilhaeyo</div></td>
@@ -1608,7 +1699,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">읽다</div><div class="rom">ikda</div></td>
-                    <td>to read (only ㄱ pronounced)</td>
+                    <td>only ㄱ pronounced</td>
                     <td class="ko-cell"><div class="ko">읽어요</div><div class="rom">igeoyo</div></td>
                     <td class="ko-cell"><div class="ko">읽었어요</div><div class="rom">igeosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">읽을 거예요</div><div class="rom">igeul geoyeyo</div></td>
@@ -1629,7 +1720,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">작다</div><div class="rom">jakda</div></td>
-                    <td>to be small</td>
+                    <td>작은</td>
                     <td class="ko-cell"><div class="ko">작아요</div><div class="rom">jagayo</div></td>
                     <td class="ko-cell"><div class="ko">작았어요</div><div class="rom">jagasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">작을 거예요</div><div class="rom">jageul geoyeyo</div></td>
@@ -1706,7 +1797,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">짧다</div><div class="rom">jjalda</div></td>
-                    <td>to be short</td>
+                    <td>짧은</td>
                     <td class="ko-cell"><div class="ko">짧아요</div><div class="rom">jjabayo</div></td>
                     <td class="ko-cell"><div class="ko">짧았어요</div><div class="rom">jjabasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">짧을 거예요</div><div class="rom">jjabeul geoyeyo</div></td>
@@ -1727,7 +1818,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">첨부하다</div><div class="rom">cheopbuhada</div></td>
-                    <td>to attach</td>
+                    <td>to attach — 첨부파일을 확인해 주세요.</td>
                     <td class="ko-cell"><div class="ko">첨부해요</div><div class="rom">cheopbuhaeyo</div></td>
                     <td class="ko-cell"><div class="ko">첨부했어요</div><div class="rom">cheopbuhaesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">첨부할 거예요</div><div class="rom">cheopbuhal geoyeyo</div></td>
@@ -1748,10 +1839,17 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">출근하다</div><div class="rom">chulgeunhada</div></td>
-                    <td>to go to work</td>
+                    <td>to go to work — 아침 9시에 출근해요.</td>
                     <td class="ko-cell"><div class="ko">출근해요</div><div class="rom">chulgeunhaeyo</div></td>
                     <td class="ko-cell"><div class="ko">출근했어요</div><div class="rom">chulgeunhaesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">출근할 거예요</div><div class="rom">chulgeunhal geoyeyo</div></td>
+                  </tr>
+                  <tr>
+                    <td class="ko-cell"><div class="ko">춤추다</div><div class="rom">chupchuda</div></td>
+                    <td>to dance</td>
+                    <td class="ko-cell"><div class="ko">춤춰요</div><div class="rom">chupchwoyo</div></td>
+                    <td class="ko-cell"><div class="ko">춤췄어요</div><div class="rom">chupchwosseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">춤출 거예요</div><div class="rom">chupchul geoyeyo</div></td>
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">춥다</div><div class="rom">chupda</div></td>
@@ -1762,7 +1860,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">크다</div><div class="rom">keuda</div></td>
-                    <td>to be big/large</td>
+                    <td>큰</td>
                     <td class="ko-cell"><div class="ko">커요</div><div class="rom">keoyo</div></td>
                     <td class="ko-cell"><div class="ko">컸어요</div><div class="rom">keosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">클 거예요</div><div class="rom">keul geoyeyo</div></td>
@@ -1783,7 +1881,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">퇴근하다</div><div class="rom">toegeunhada</div></td>
-                    <td>to leave work</td>
+                    <td>to leave work — 저녁 6시에 퇴근해요.</td>
                     <td class="ko-cell"><div class="ko">퇴근해요</div><div class="rom">toegeunhaeyo</div></td>
                     <td class="ko-cell"><div class="ko">퇴근했어요</div><div class="rom">toegeunhaesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">퇴근할 거예요</div><div class="rom">toegeunhal geoyeyo</div></td>
@@ -1811,7 +1909,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">핥다</div><div class="rom">halda</div></td>
-                    <td>to lick (only ㄹ pronounced)</td>
+                    <td>only ㄹ is pronounced</td>
                     <td class="ko-cell"><div class="ko">핥아요</div><div class="rom">hatayo</div></td>
                     <td class="ko-cell"><div class="ko">핥았어요</div><div class="rom">hatasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">핥을 거예요</div><div class="rom">hateul geoyeyo</div></td>

--- a/blog_posts/korean-learning-notes.md
+++ b/blog_posts/korean-learning-notes.md
@@ -1034,7 +1034,7 @@ fa-icon: language
                   <!-- Generated from blog_posts/verbs_tenses.tsv (simple -다 verbs only; edit TSV, then run: python tools_update_verb_table.py) -->
                   <tr>
                     <td class="ko-cell"><div class="ko">가깝다</div><div class="rom">gakkapda</div></td>
-                    <td>@level2/2025-12-12-Class-10.txt (Vocab; also Class 8 dialogue)</td>
+                    <td>to be close/near</td>
                     <td class="ko-cell"><div class="ko">가까워요</div><div class="rom">gakkawoyo</div></td>
                     <td class="ko-cell"><div class="ko">가까웠어요</div><div class="rom">gakkawosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">가까울 거예요</div><div class="rom">gakkaul geoyeyo</div></td>

--- a/blog_posts/korean-learning-notes.md
+++ b/blog_posts/korean-learning-notes.md
@@ -1153,7 +1153,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">길다</div><div class="rom">gilda</div></td>
-                    <td>긴</td>
+                    <td>to be long</td>
                     <td class="ko-cell"><div class="ko">길어요</div><div class="rom">gireoyo</div></td>
                     <td class="ko-cell"><div class="ko">길었어요</div><div class="rom">gireosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">길 거예요</div><div class="rom">gil geoyeyo</div></td>
@@ -1321,7 +1321,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">많다</div><div class="rom">manda</div></td>
-                    <td>only ㄴ pronounced</td>
+                    <td>to be many/much (only ㄴ pronounced)</td>
                     <td class="ko-cell"><div class="ko">많아요</div><div class="rom">manayo</div></td>
                     <td class="ko-cell"><div class="ko">많았어요</div><div class="rom">manasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">많을 거예요</div><div class="rom">maneul geoyeyo</div></td>
@@ -1525,8 +1525,8 @@ fa-icon: language
                   <tr>
                     <td class="ko-cell"><div class="ko">쉬다</div><div class="rom">swida</div></td>
                     <td>to rest</td>
-                    <td class="ko-cell"><div class="ko">쉬요</div><div class="rom">swiyo</div></td>
-                    <td class="ko-cell"><div class="ko">슀어요</div><div class="rom">swisseoyo</div></td>
+                    <td class="ko-cell"><div class="ko">쉬어요</div><div class="rom">swieoyo</div></td>
+                    <td class="ko-cell"><div class="ko">쉬었어요</div><div class="rom">swieosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">쉴 거예요</div><div class="rom">swil geoyeyo</div></td>
                   </tr>
                   <tr>
@@ -1664,7 +1664,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">읊다</div><div class="rom">eulda</div></td>
-                    <td>only ㅍ is pronounced (exception to first consonant rule)</td>
+                    <td>to recite/chant (only ㅍ pronounced)</td>
                     <td class="ko-cell"><div class="ko">읊어요</div><div class="rom">eupeoyo</div></td>
                     <td class="ko-cell"><div class="ko">읊었어요</div><div class="rom">eupeosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">읊을 거예요</div><div class="rom">eupeul geoyeyo</div></td>
@@ -1699,7 +1699,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">읽다</div><div class="rom">ikda</div></td>
-                    <td>only ㄱ pronounced</td>
+                    <td>to read (only ㄱ pronounced)</td>
                     <td class="ko-cell"><div class="ko">읽어요</div><div class="rom">igeoyo</div></td>
                     <td class="ko-cell"><div class="ko">읽었어요</div><div class="rom">igeosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">읽을 거예요</div><div class="rom">igeul geoyeyo</div></td>
@@ -1720,7 +1720,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">작다</div><div class="rom">jakda</div></td>
-                    <td>작은</td>
+                    <td>to be small</td>
                     <td class="ko-cell"><div class="ko">작아요</div><div class="rom">jagayo</div></td>
                     <td class="ko-cell"><div class="ko">작았어요</div><div class="rom">jagasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">작을 거예요</div><div class="rom">jageul geoyeyo</div></td>
@@ -1797,7 +1797,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">짧다</div><div class="rom">jjalda</div></td>
-                    <td>짧은</td>
+                    <td>to be short</td>
                     <td class="ko-cell"><div class="ko">짧아요</div><div class="rom">jjabayo</div></td>
                     <td class="ko-cell"><div class="ko">짧았어요</div><div class="rom">jjabasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">짧을 거예요</div><div class="rom">jjabeul geoyeyo</div></td>
@@ -1818,7 +1818,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">첨부하다</div><div class="rom">cheopbuhada</div></td>
-                    <td>to attach — 첨부파일을 확인해 주세요.</td>
+                    <td>to attach</td>
                     <td class="ko-cell"><div class="ko">첨부해요</div><div class="rom">cheopbuhaeyo</div></td>
                     <td class="ko-cell"><div class="ko">첨부했어요</div><div class="rom">cheopbuhaesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">첨부할 거예요</div><div class="rom">cheopbuhal geoyeyo</div></td>
@@ -1839,7 +1839,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">출근하다</div><div class="rom">chulgeunhada</div></td>
-                    <td>to go to work — 아침 9시에 출근해요.</td>
+                    <td>to go to work</td>
                     <td class="ko-cell"><div class="ko">출근해요</div><div class="rom">chulgeunhaeyo</div></td>
                     <td class="ko-cell"><div class="ko">출근했어요</div><div class="rom">chulgeunhaesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">출근할 거예요</div><div class="rom">chulgeunhal geoyeyo</div></td>
@@ -1860,7 +1860,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">크다</div><div class="rom">keuda</div></td>
-                    <td>큰</td>
+                    <td>to be big/large</td>
                     <td class="ko-cell"><div class="ko">커요</div><div class="rom">keoyo</div></td>
                     <td class="ko-cell"><div class="ko">컸어요</div><div class="rom">keosseoyo</div></td>
                     <td class="ko-cell"><div class="ko">클 거예요</div><div class="rom">keul geoyeyo</div></td>
@@ -1881,7 +1881,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">퇴근하다</div><div class="rom">toegeunhada</div></td>
-                    <td>to leave work — 저녁 6시에 퇴근해요.</td>
+                    <td>to leave work</td>
                     <td class="ko-cell"><div class="ko">퇴근해요</div><div class="rom">toegeunhaeyo</div></td>
                     <td class="ko-cell"><div class="ko">퇴근했어요</div><div class="rom">toegeunhaesseoyo</div></td>
                     <td class="ko-cell"><div class="ko">퇴근할 거예요</div><div class="rom">toegeunhal geoyeyo</div></td>
@@ -1909,7 +1909,7 @@ fa-icon: language
                   </tr>
                   <tr>
                     <td class="ko-cell"><div class="ko">핥다</div><div class="rom">halda</div></td>
-                    <td>only ㄹ is pronounced</td>
+                    <td>to lick (only ㄹ pronounced)</td>
                     <td class="ko-cell"><div class="ko">핥아요</div><div class="rom">hatayo</div></td>
                     <td class="ko-cell"><div class="ko">핥았어요</div><div class="rom">hatasseoyo</div></td>
                     <td class="ko-cell"><div class="ko">핥을 거예요</div><div class="rom">hateul geoyeyo</div></td>

--- a/blog_posts/verbs_tenses.tsv
+++ b/blog_posts/verbs_tenses.tsv
@@ -1,5 +1,5 @@
 Verb (dict.)	English meaning	Present	Past	Future
-가깝다	@level2/2025-12-12-Class-10.txt (Vocab; also Class 8 dialogue)	가까워요	가까웠어요	가까울 거예요
+가깝다	to be close/near	가까워요	가까웠어요	가까울 거예요
 가다	go	가요	갔어요	갈 거예요
 가르치다	to teach / to tell (someone)	가르쳐요	가르쳤어요	가르칠 거예요
 가져오다	to bring	가져와요	가져왔어요	가져올 거예요

--- a/blog_posts/verbs_tenses.tsv
+++ b/blog_posts/verbs_tenses.tsv
@@ -1,5 +1,5 @@
 Verb (dict.)	English meaning	Present	Past	Future
-가깝다	to be close/near	가까워요	가까웠어요	가까울 거예요
+가깝다	@level2/2025-12-12-Class-10.txt (Vocab; also Class 8 dialogue)	가까워요	가까웠어요	가까울 거예요
 가다	go	가요	갔어요	갈 거예요
 가르치다	to teach / to tell (someone)	가르쳐요	가르쳤어요	가르칠 거예요
 가져오다	to bring	가져와요	가져왔어요	가져올 거예요

--- a/blog_posts/verbs_tenses.tsv
+++ b/blog_posts/verbs_tenses.tsv
@@ -8,6 +8,7 @@ Verb (dict.)	English meaning	Present	Past	Future
 갑니다	go	갑녀요	갑녔어요	갑닐 거예요
 걱정하다	to worry	걱정해요	걱정했어요	걱정할 거예요
 건너다	to cross	건너요	건넜어요	건널 거예요
+걷다	to walk	걸어요	걸었어요	걸을 거예요
 걸어가다	to go by walking	걸어가요	걸어갔어요	걸어갈 거예요
 걸어오다	to come by walking	걸어와요	걸어왔어요	걸어올 거예요
 고맙습니다	Thank you (polite)	고맙습녀요	고맙습녔어요	고맙습닐 거예요
@@ -27,15 +28,19 @@ Verb (dict.)	English meaning	Present	Past	Future
 내려오다	to come down	내려와요	내려왔어요	내려올 거예요
 내리다	to get off	내려요	내렸어요	내릴 거예요
 놀다	to play	놀아요	놀았어요	놀 거예요
+노래하다	to sing	노래해요	노래했어요	노래할 거예요
 늦다	to be late	늦어요	늦었어요	늦을 거예요
+닫다	to close	닫아요	닫았어요	닫을 거예요
 달다	sweet	달아요	달았어요	달 거예요
 덥다	hot	더워요	더웠어요	더울 거예요
+도와주다	to help (someone)	도와줘요	도와줬어요	도와줄 거예요
 듣다	to listen	들어요	들었어요	들을 거예요
 들어가다	to go in / enter	들어가요	들어갔어요	들어갈 거예요
 들어오다	to come in / enter	들어와요	들어왔어요	들어올 거예요
 따뜻하다	warm	따뜻해요	따뜻했어요	따뜻할 거예요
 뚱뚱하다	to be fat	뚱뚱해요	뚱뚱했어요	뚱뚱할 거예요
 마르다	to be skinny / thin	말라요	말랐어요	마를 거예요
+마시다	to drink	마셔요	마셨어요	마실 거예요
 마십니다	drink	마십녀요	마십녔어요	마십닐 거예요
 만나다	to meet	만나요	만났어요	만날 거예요
 만들다	to make	만들어요	만들었어요	만들 거예요
@@ -53,6 +58,8 @@ Verb (dict.)	English meaning	Present	Past	Future
 물어보다	to ask	물어봐요	물어봤어요	물어볼 거예요
 바쁘다	to be busy	바빠요	바빴어요	바쁠 거예요
 배우다	to learn	배워요	배웠어요	배울 거예요
+버리다	to throw away	버려요	버렸어요	버릴 거예요
+벗다	to take off (clothes)	벗어요	벗었어요	벗을 거예요
 보내다	to spend (time)	보내요	보냈어요	보낼 거예요
 보다	see/watch	봐요	봤어요	볼 거예요
 보이다	to be visible / to see	보여요	보였어요	보일 거예요
@@ -61,10 +68,13 @@ Verb (dict.)	English meaning	Present	Past	Future
 빌리다	to borrow	빌려요	빌렸어요	빌릴 거예요
 사다	to buy	사요	샀어요	살 거예요
 사랑하다	to love	사랑해요	사랑했어요	사랑할 거예요
+산책하다	to take a walk	산책해요	산책했어요	산책할 거예요
 살다	to live	살아요	살았어요	살 거예요
 새다	To leak	새요	샜어요	샐 거예요
+서다	to stand	서요	섰어요	설 거예요
 소개하다	to introduce	소개해요	소개했어요	소개할 거예요
 쇼핑하다	to go shopping	쇼핑해요	쇼핑했어요	쇼핑할 거예요
+수영하다	to swim	수영해요	수영했어요	수영할 거예요
 쉬다	to rest	쉬요	슀어요	쉴 거예요
 습하다	humid	습해요	습했어요	습할 거예요
 시다	sour	셔요	셨어요	실 거예요
@@ -76,6 +86,8 @@ Verb (dict.)	English meaning	Present	Past	Future
 앉다	to sit	앉아요	앉았어요	앉을 거예요
 알다	to know	알아요	알았어요	알 거예요
 연락하다	to contact	연락해요	연락했어요	연락할 거예요
+열다	to open	열어요	열었어요	열 거예요
+여행하다	to travel	여행해요	여행했어요	여행할 거예요
 예쁘다	to be pretty	예뻐요	예뻤어요	예쁠 거예요
 오다	come	와요	왔어요	올 거예요
 올라가다	to go up	올라가요	올라갔어요	올라갈 거예요
@@ -87,6 +99,7 @@ Verb (dict.)	English meaning	Present	Past	Future
 읊다	only ㅍ is pronounced (exception to first consonant rule)	읊어요	읊었어요	읊을 거예요
 이사하다	to move (houses)	이사해요	이사했어요	이사할 거예요
 이야기하다	to talk	이야기해요	이야기했어요	이야기할 거예요
+일어나다	to wake up	일어나요	일어났어요	일어날 거예요
 일하다	to work	일해요	일했어요	일할 거예요
 읽다	only ㄱ pronounced	읽어요	읽었어요	읽을 거예요
 입다	to wear	입어요	입었어요	입을 거예요
@@ -110,6 +123,7 @@ Verb (dict.)	English meaning	Present	Past	Future
 청소하다	to clean	청소해요	청소했어요	청소할 거예요
 축하하다	to congratulate	축하해요	축하했어요	축하할 거예요
 출근하다	to go to work — 아침 9시에 출근해요.	출근해요	출근했어요	출근할 거예요
+춤추다	to dance	춤춰요	춤췄어요	춤출 거예요
 춥다	cold	추워요	추웠어요	추울 거예요
 크다	큰	커요	컸어요	클 거예요
 타다	to get on/ride	타요	탔어요	탈 거예요


### PR DESCRIPTION
Add missing Korean verbs to the learning notes.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9cfc78d6-a410-4f9e-b429-f91e8311914f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cfc78d6-a410-4f9e-b429-f91e8311914f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only additions to markdown/TSV reference tables; no code paths, build logic, or runtime behavior changes.
> 
> **Overview**
> Expands the Korean verb conjugation reference by adding several missing verbs (e.g., `걷다`, `노래하다`, `닫다`, `도와주다`, `마시다`, `버리다`, `벗다`, `산책하다`, `서다`, `수영하다`, `열다`, `여행하다`, `일어나다`, `춤추다`) with their present/past/future forms.
> 
> Updates both the source data file `blog_posts/verbs_tenses.tsv` and the generated verb table embedded in `blog_posts/korean-learning-notes.md` to keep them in sync.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ddd3e7ec7cc32051a85e3c5ca5a07e8dcd3b00f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->